### PR TITLE
Impl trait contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,5 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.86"
 quote = "1.0.36"
+static_assertions = "1.1.0"
 syn = { version = "2.0.63", features = [ "full" ] }

--- a/examples/example_basic.rs
+++ b/examples/example_basic.rs
@@ -14,11 +14,14 @@ mod platform {
 
     //Declares a constant that must be provided for each platform
     pub use OS_NAME as PLATFORM_NAME;
+
+    impl FilePathDescription<String> for FilePathDescriber {}
+
 }
 
 //trait that each platform specific FilePathDescriberImpl must implement (by convention)
-trait FilePathDescription {
-    fn description(&self) -> String;
+trait FilePathDescription<T> {
+    fn description(&self) -> T;
 }
 
 fn main() {

--- a/examples/example_basic.rs
+++ b/examples/example_basic.rs
@@ -15,11 +15,11 @@ mod platform {
     //Declares a constant that must be provided for each platform
     pub use OS_NAME as PLATFORM_NAME;
 
+    //trait that each platform specific FilePathDescriberImpl must implement
     impl FilePathDescription<String> for FilePathDescriber {}
 
 }
 
-//trait that each platform specific FilePathDescriberImpl must implement (by convention)
 trait FilePathDescription<T> {
     fn description(&self) -> T;
 }

--- a/examples/example_basic/maclinuxshared.rs
+++ b/examples/example_basic/maclinuxshared.rs
@@ -2,7 +2,7 @@ use crate::FilePathDescription;
 
 pub struct UnixImpl;
 
-impl FilePathDescription for UnixImpl {
+impl FilePathDescription<String> for UnixImpl {
     fn description(&self) -> String {
         return "Directories are seperated by /, e.g. example/file/path".to_string();
     }

--- a/examples/example_basic/unsupported.rs
+++ b/examples/example_basic/unsupported.rs
@@ -4,8 +4,16 @@ pub type FilePathDescriberImpl = UnsupportedImpl;
 pub const OS_NAME: &'static str = "unknown";
 pub struct UnsupportedImpl;
 
-impl FilePathDescription<String> for UnsupportedImpl {
+impl ToString for UnsupportedImpl {
+    fn to_string(&self) -> String {
+        "This platform is unknown so we do not know how file paths are written.".to_string();
+    }
+}
+
+//Example blanket implementation that fulfills contract
+impl<T> FilePathDescription<String> for T
+where T : ToString {
     fn description(&self) -> String {
-        return "This platform is unknown so we do not know how file paths are written.".to_string();
+        return self.to_string();
     }
 }

--- a/examples/example_basic/unsupported.rs
+++ b/examples/example_basic/unsupported.rs
@@ -4,7 +4,7 @@ pub type FilePathDescriberImpl = UnsupportedImpl;
 pub const OS_NAME: &'static str = "unknown";
 pub struct UnsupportedImpl;
 
-impl FilePathDescription for UnsupportedImpl {
+impl FilePathDescription<String> for UnsupportedImpl {
     fn description(&self) -> String {
         return "This platform is unknown so we do not know how file paths are written.".to_string();
     }

--- a/examples/example_basic/windows.rs
+++ b/examples/example_basic/windows.rs
@@ -4,7 +4,7 @@ pub type FilePathDescriberImpl = WindowsImpl;
 pub const OS_NAME: &'static str = "windows";
 pub struct WindowsImpl;
 
-impl FilePathDescription for WindowsImpl {
+impl FilePathDescription<String> for WindowsImpl {
     fn description(&self) -> String {
         return "Directories are seperated by \\, e.g. example\\file\\path".to_string();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,9 @@ use syn::{bracketed, parse::Parse, parse_macro_input, punctuated::Punctuated, sp
 /// 
 ///     /// A platform-specific error type, renamed and exported from the parent module as "PlatformError".
 ///     pub use ErrorImpl as PlatformError;
+/// 
+///     /// Trait contract that specifies that each platform-specific PlatformService will implement SomeTrait
+///     impl SomeTrait for PlatformService;
 /// }
 /// ```
 /// 
@@ -58,6 +61,8 @@ use syn::{bracketed, parse::Parse, parse_macro_input, punctuated::Punctuated, sp
 /// pub type PlatformService<T> = platform::ServiceImpl<T>;
 /// #[doc = "A platform-specific error type, renamed and exported from the parent module as \"PlatformError\"."]
 /// pub use platform::ErrorImpl as PlatformError;
+/// 
+/// static_assertions::assert_impl_all!(PlatformService : SomeTrait);
 /// ```
 #[proc_macro_attribute]
 pub fn platform_spi(args: TokenStream, item: TokenStream) -> TokenStream {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ use syn::{bracketed, parse::Parse, parse_macro_input, punctuated::Punctuated, sp
 ///     pub use ErrorImpl as PlatformError;
 /// 
 ///     /// Trait contract that specifies that each platform-specific PlatformService will implement SomeTrait
-///     impl SomeTrait for PlatformService;
+///     impl SomeTrait for PlatformService{}
 /// }
 /// ```
 /// 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,8 @@ pub fn platform_spi(args: TokenStream, item: TokenStream) -> TokenStream {
     // SPI type aliases hoisted from the module declaration.
     let aliases = &rewritten_decl.aliases;
 
+    let (types, impls) = &rewritten_decl.implementations;
+
     quote! {
         #( 
             #[cfg(target_os = #target_names)]
@@ -89,6 +91,8 @@ pub fn platform_spi(args: TokenStream, item: TokenStream) -> TokenStream {
         #mod_import
 
         #(#aliases)*
+
+        #(static_assertions::assert_impl_all!(#types : #impls);)*
     }.into()
 
 }
@@ -147,6 +151,7 @@ impl Parse for SpiAttributes {
 struct SpiModule {
     mod_import_decl: syn::ItemMod,
     aliases: Vec<syn::Item>,
+    implementations: (Vec<syn::Type>, Vec<syn::Path>)
 }
 // implementing TryFrom rather than Parse allows us to reuse most of the parse logic
 // from ItemMod, plus be a little more fine-grained with errors (e.g. we can report 
@@ -158,7 +163,7 @@ impl TryFrom<&syn::ItemMod> for SpiModule {
         let parent_module = mod_decl.ident.clone();
 
         let mod_aliases = check_spi_items(mod_decl)?;
-        let aliases = hoist_aliases(mod_aliases, parent_module)?;
+        let (aliases, implementations) = hoist_aliases_and_generate_impls(mod_aliases, parent_module)?;
 
         let mod_import_decl = syn::ItemMod {
             attrs: mod_decl.attrs.clone(),
@@ -170,7 +175,7 @@ impl TryFrom<&syn::ItemMod> for SpiModule {
             semi: Some(Semi(mod_decl.ident.span())),
         };
 
-        Ok(Self { mod_import_decl, aliases })
+        Ok(Self { mod_import_decl, aliases, implementations})
     }
 }
 
@@ -186,16 +191,29 @@ fn check_spi_items(mod_decl: &syn::ItemMod) -> Result<&[syn::Item], TokenStream>
     }
 }
 
-fn hoist_aliases(mod_aliases: &[syn::Item], parent_module: syn::Ident) -> Result<Vec<syn::Item>, TokenStream> {
+fn hoist_aliases_and_generate_impls(mod_aliases: &[syn::Item], parent_module: syn::Ident) -> Result<(Vec<syn::Item>, (Vec<syn::Type>, Vec<syn::Path>)), TokenStream> {
     let mut invalid_items: Vec<TokenStream2> = vec![];
     let mut aliases: Vec<syn::Item> = vec![];
+    let mut impl_types: Vec<syn::Type> = vec![];
+    let mut impls: Vec<syn::Path> = vec![];
 
     for item in mod_aliases {
+        if let syn::Item::Impl(impl_item) = item {
+            if let (0, None, Some((None, path, _))) = (impl_item.items.len(), &impl_item.generics.where_clause, &impl_item.trait_) {
+                impl_types.push(*impl_item.self_ty.clone());
+                impls.push(path.clone());
+            } else {
+                invalid_items.push(quote_spanned! {
+                    item.span() => compile_error!("Impl block is incorrectly formed, only format of 'impl Trait for Type {}' is allowed")
+                });
+            }
+            continue;
+        }
         let hoisted = match item {
             syn::Item::Type(alias) => hoist_type_alias(alias, &parent_module),
             syn::Item::Use(alias) => hoist_use_alias(alias, &parent_module),
             _ => Err(quote_spanned! {
-                item.span() => compile_error!("Only 'type' and 'use' items are supported in an SPI module declaration")
+                item.span() => compile_error!("Only 'type', 'use', and 'impl' items are supported in an SPI module declaration but found")
             })
         };
         match hoisted {
@@ -209,7 +227,7 @@ fn hoist_aliases(mod_aliases: &[syn::Item], parent_module: syn::Ident) -> Result
         return Err(collected.into())
     }
 
-    Ok(aliases)
+    Ok((aliases, (impl_types, impls)))
 }
 
 fn hoist_type_alias(alias: &syn::ItemType, parent_module: &syn::Ident) -> Result<syn::Item, TokenStream2> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,9 @@ use syn::{bracketed, parse::Parse, parse_macro_input, punctuated::Punctuated, sp
 /// Any "type" and "use" declarations in the module content block will be 
 /// converted into items in the parent module, which refer to items in the target platform
 /// module. These type aliases are the "SPI", required to be implemented
-/// for each supported platform. Item declarations other than "type" and "use" are not supported.
+/// for each supported platform. Additionally, an "impl" declaration can be made to specify 
+/// that each platform type must implement a specific trait.
+/// Item declarations other than "type", "use", and "impl" are not supported.
 /// 
 /// ## Unsupported Platforms
 /// One additional source file, "unsupported.rs", will be used for attempted compilation 


### PR DESCRIPTION
A couple notes and limitations:

I disallow the usage of `!` in the impl contract clause.  This character is allowed per both the [rust reference](https://doc.rust-lang.org/reference/items/implementations.html) and inside of `syn`, but I can't for the life of me figure out what it's used for (the reference doesn't give any examples, maybe this is some Rust pattern I'm unfamiliar with).  Let me know if you know and if we should validly support it.

Where clauses aren't allowed as there's no way I could find to validate them with static assertions.

I've also put this logic outside of the match clause for hoisting alias and use items since using an enum to manage multiple return types felt clunky, but if there's an idiomatic pattern for it you like I could move it in.